### PR TITLE
🏷️ Tag updated to Username

### DIFF
--- a/src/events/StartupReady.ts
+++ b/src/events/StartupReady.ts
@@ -15,7 +15,7 @@ class StartupReady implements IEvent {
 	}
 
 	execute(client: Bot): void {
-		Logger.info(`Ready! Logged in as ${yellow(client.user.tag)}`);
+		Logger.info(`Ready! Logged in as ${yellow(client.user.username)}`);
 	}
 }
 

--- a/src/interactors/buttons/SignupListBtn.ts
+++ b/src/interactors/buttons/SignupListBtn.ts
@@ -35,7 +35,7 @@ class SignupListBtn implements IButton {
 			signedUp
 				.map(
 					(member) =>
-						`${member.displayName || member.user.username} (${member.user.tag})`,
+						`${member.displayName || member.user.username} (${member.user.username})`,
 				)
 				.join("\n") || "No one";
 
@@ -43,7 +43,7 @@ class SignupListBtn implements IButton {
 			signedOff
 				.map(
 					(member) =>
-						`${member.displayName || member.user.username} (${member.user.tag})`,
+						`${member.displayName || member.user.username} (${member.user.username})`,
 				)
 				.join("\n") || "No one";
 


### PR DESCRIPTION
Discord doesn't like tags anymore. They like usernames better.

## Describe your changes

This changes `user.tag` into `user.username`.
Else users that have changed to the new system will show up as `username#0`. 
This is ugly.

## Issue ticket number and link

No Issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [ ] The implemented feature was tested on a development bot.
- [x] I've filled in a brief description above.
- [x] I've linked the appropiate issue ticket.
