### PR TITLE
🪛 Tweak build action to run of master PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,9 @@
 name: ESLint PR
 
 on:
-  push:
+  pull_request:
     branches:
-      - development
-      - "feature/**"
-      - "fix/**"
-      - "bug/**"
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
## Describe your changes

Makes it so that the build.yml GitHub action will run whenever a PR is made to the master branch.

## Issue ticket number and link

No issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The implemented feature was tested on a development bot.
- [x] I've filled in a brief description above.
- [x] I've linked the appropiate issue ticket.
