### PR TITLE
🪄PingRole will embed if using '!'

### DIFF
--- a/src/events/PingRoleSentEvent.ts
+++ b/src/events/PingRoleSentEvent.ts
@@ -24,7 +24,7 @@ class PingRoleSentEvent implements IEvent {
 
 	async execute(message: Message): Promise<void> {
 		if (message.author.bot) return;
-		if (message.content.startsWith("!")) return;
+		if (!message.content.startsWith("!")) return;
 
 		let pingRole: Role;
 


### PR DESCRIPTION
## Describe your changes

Previously if you do an `@pingrole` in discord the Ping Role Embed will immediately popup. However this feature is less wanted than just pinging that role. So this effect of the embed only triggers when you start the message with a `!`.

## Issue ticket number and link

No Issue

## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The implemented feature was tested on a development bot.
- [x] I've filled in a brief description above.
- [x] I've linked the appropiate issue ticket.
